### PR TITLE
V set element quantity

### DIFF
--- a/src/test/java/org/open_structures/matching/MatchingTest.java
+++ b/src/test/java/org/open_structures/matching/MatchingTest.java
@@ -98,4 +98,23 @@ public class MatchingTest {
         assertThat(matches.get(person2)).isEqualTo(task2);
         assertThat(matches.get(person3)).isEqualTo(task3);
     }
+
+    /**
+     * In this test we need 2 people for task1 and one person for task2.
+     */
+    @Test
+    public void shouldFindMatchingWithMultipleQuantitiesOfU() {
+        // given
+        Matching<String, String> matching = Matching.newMatching(skillsPredicate, newHashSet(person1, person2, person3), Map.of(task1, 2, task2, 1));
+        matching.findMatching();
+
+        // when
+        Map<String, String> matches = matching.getMatches();
+
+        // then
+        assertThat(matches.get(person1)).isEqualTo(task1);
+        assertThat(matches.get(person2)).isEqualTo(task1);
+        assertThat(matches.get(person3)).isEqualTo(task2);
+
+    }
 }


### PR DESCRIPTION
Adding support for setting the quantity of elements in the V set. An example of when that is useful is when U represents people and V represents job roles and some of those roles need several people. For example, if a role requires 3 people and U contains two people that qualify for that role then they both could be matched (assigned) to it.